### PR TITLE
Fix: tmux tab jump always lands on wrong tab in shared-session setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.bak.*
 .claude/
 .ruff_cache/
+.plans/

--- a/src/clorch/state/manager.py
+++ b/src/clorch/state/manager.py
@@ -83,6 +83,23 @@ class StateManager:
         agent.session_name = self._history.resolve(agent.session_id)
         return agent
 
+    def remove_session(self, session_id: str) -> bool:
+        """Delete the state file for *session_id*.
+
+        Returns ``True`` if the file was removed, ``False`` if it did not exist
+        or the session_id was invalid.  Uses the same ID validation as
+        ``get_agent`` to prevent path traversal.
+        """
+        if not _VALID_SESSION_ID.match(session_id):
+            log.warning("remove_session: invalid session_id %r", session_id)
+            return False
+        path = self._state_dir / f"{session_id}.json"
+        try:
+            path.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+
     def verify_status(self, session_id: str, expected: "AgentStatus") -> bool:
         """Re-read the state file and confirm the agent is still in *expected* status.
 

--- a/src/clorch/tmux/navigator.py
+++ b/src/clorch/tmux/navigator.py
@@ -118,6 +118,16 @@ def jump_to_tab(agent: AgentState) -> bool:
     return False
 
 
+def _is_safe_tmux_name(value: str) -> bool:
+    """Return True if *value* is safe to embed in a tmux ``-t`` target.
+
+    Rejects empty strings and values containing ``:`` (tmux session/window
+    separator) or ``"`` / ``'`` (shell quoting), which could cause the target
+    to address an unintended session or pane.
+    """
+    return bool(value) and not any(c in value for c in (':', '"', "'"))
+
+
 def select_tmux_pane(agent: AgentState) -> bool:
     """Focus the tmux window + pane for this agent.
 
@@ -144,6 +154,9 @@ def select_tmux_pane(agent: AgentState) -> bool:
     # Prefer window index — names can be duplicated across windows,
     # and tmux refuses to select-window by an ambiguous name.
     window_target = agent.tmux_window_index or agent.tmux_window
+    if not _is_safe_tmux_name(window_target):
+        log.warning("select_tmux_pane: unsafe window target %r", window_target)
+        return False
     target = f"{client_session}:{window_target}"
     result = tmux.run_command("select-window", "-t", target, check=False)
     if result.returncode != 0:

--- a/src/clorch/tui/app.py
+++ b/src/clorch/tui/app.py
@@ -805,6 +805,7 @@ class OrchestratorApp(App):
                 return
             # Fallback: no tab found via tty/window mapping; use select-window.
             if select_tmux_pane(agent):
+                bring_terminal_to_front()
                 self.notify(f"Jumped to {name}")
                 return
 

--- a/src/clorch/tui/app.py
+++ b/src/clorch/tui/app.py
@@ -786,8 +786,7 @@ class OrchestratorApp(App):
 
         # Dead process check — remove stale state file immediately
         if agent.pid and not pid_alive(agent.pid):
-            state_file = self._manager._state_dir / f"{agent.session_id}.json"
-            state_file.unlink(missing_ok=True)
+            self._manager.remove_session(agent.session_id)
             self.notify(f"{name}: process dead, removed", severity="warning")
             return
 

--- a/src/clorch/tui/app.py
+++ b/src/clorch/tui/app.py
@@ -4,28 +4,28 @@ from __future__ import annotations
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
 from textual.events import Key
 from textual.screen import ModalScreen
-from textual.containers import Horizontal, Vertical
 from textual.widgets import Input, Label, Static
 
-from clorch.state.manager import StateManager
-from clorch.state.models import AgentState, StatusSummary, ActionItem, build_action_queue
-from clorch.constants import (
-    AgentStatus,
-    ANIM_INTERVAL,
-    TELEMETRY_HISTORY_LEN,
-    TELEMETRY_BUCKET_TICKS,
-)
 from clorch.config import RULES_PATH
-from clorch.rules import RulesConfig, load_rules, save_rules, evaluate
-from clorch.tui.widgets.session_list import SessionList, ListHeader
+from clorch.constants import (
+    ANIM_INTERVAL,
+    TELEMETRY_BUCKET_TICKS,
+    TELEMETRY_HISTORY_LEN,
+    AgentStatus,
+)
+from clorch.rules import RulesConfig, evaluate, load_rules, save_rules
+from clorch.state.manager import StateManager
+from clorch.state.models import ActionItem, AgentState, StatusSummary, build_action_queue
 from clorch.tui.widgets.agent_detail import AgentDetail
-from clorch.tui.widgets.header_bar import HeaderBar
 from clorch.tui.widgets.context_footer import ContextFooter
-from clorch.tui.widgets.telemetry_panel import TelemetryPanel
 from clorch.tui.widgets.event_log import EventLog
+from clorch.tui.widgets.header_bar import HeaderBar
+from clorch.tui.widgets.session_list import ListHeader, SessionList
 from clorch.tui.widgets.settings_panel import SettingsPanel
+from clorch.tui.widgets.telemetry_panel import TelemetryPanel
 
 
 class PromptScreen(ModalScreen[str | None]):
@@ -91,7 +91,8 @@ class HelpScreen(ModalScreen[None]):
 
     def compose(self) -> ComposeResult:
         from rich.text import Text
-        from clorch.constants import CYAN, GREEN, RED, GREY, YELLOW
+
+        from clorch.constants import CYAN, GREEN, GREY, RED, YELLOW
 
         text = Text()
         text.append("CLAUDE ORCH HELP\n\n", style=f"bold {CYAN}")
@@ -679,7 +680,7 @@ class OrchestratorApp(App):
         to the terminal tab so the user can approve/deny manually.
         Agents in unreachable terminals are blocked with a warning.
         """
-        from clorch.tmux.navigator import map_agent_to_window, jump_to_tab
+        from clorch.tmux.navigator import jump_to_tab
         from clorch.tmux.session import TmuxSession
 
         name = agent.project_name or agent.session_id[:12]
@@ -764,11 +765,11 @@ class OrchestratorApp(App):
         with a warning.
         """
         from clorch.tmux.navigator import (
+            bring_terminal_to_front,
             jump_to_tab,
             jump_to_tmux_tab,
-            select_tmux_pane,
-            bring_terminal_to_front,
             pid_alive,
+            select_tmux_pane,
         )
         from clorch.tmux.session import TmuxSession
 

--- a/src/clorch/tui/app.py
+++ b/src/clorch/tui/app.py
@@ -791,12 +791,20 @@ class OrchestratorApp(App):
             self.notify(f"{name}: process dead, removed", severity="warning")
             return
 
-        # tmux session: select-window + select-pane, then switch terminal tab
+        # tmux session: activate the terminal tab already showing the target
+        # window.  Do NOT call select-window first — in a shared tmux session
+        # (all tabs attached to the same session), select-window would switch
+        # every client, including the clorch tab, to the target window.
+        # If tab lookup fails (no client is currently viewing that window),
+        # fall back to select-window as a last resort.
         if agent.tmux_window:
-            if select_tmux_pane(agent):
-                tmux = TmuxSession(session_name=agent.tmux_session or None)
-                jump_to_tmux_tab(tmux, agent.tmux_window)
+            tmux = TmuxSession(session_name=agent.tmux_session or None)
+            if jump_to_tmux_tab(tmux, agent.tmux_window):
                 bring_terminal_to_front()
+                self.notify(f"Jumped to {name}")
+                return
+            # Fallback: no tab found via tty/window mapping; use select-window.
+            if select_tmux_pane(agent):
                 self.notify(f"Jumped to {name}")
                 return
 

--- a/tests/test_jump_to_session.py
+++ b/tests/test_jump_to_session.py
@@ -1,0 +1,137 @@
+"""Tests for OrchestratorApp._jump_to_session tmux tab-jump branching.
+
+Covers the fix for shared-tmux-session tab corruption: jump_to_tmux_tab is
+called before select_tmux_pane, and select_tmux_pane is skipped entirely when
+jump_to_tmux_tab succeeds (avoids session-wide select-window side-effects).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from clorch.state.models import AgentState
+
+
+def _make_agent(
+    tmux_window: str = "cre-1",
+    tmux_session: str = "claude",
+    tmux_pane: str = "",
+    pid: int = 12345,
+    project_name: str = "cre-project",
+    session_id: str = "sess-abc",
+) -> AgentState:
+    return AgentState(
+        session_id=session_id,
+        project_name=project_name,
+        tmux_window=tmux_window,
+        tmux_session=tmux_session,
+        tmux_pane=tmux_pane,
+        pid=pid,
+    )
+
+
+def _make_app():
+    from clorch.tui.app import OrchestratorApp
+    app = object.__new__(OrchestratorApp)
+    app.notify = MagicMock()  # type: ignore[attr-defined]
+    return app
+
+
+class TestJumpToSessionTmuxBranch:
+    """Unit tests for the tmux path of _jump_to_session."""
+
+    def _run(self, app, agent, *, tab_found: bool, pane_selected: bool):
+        """Run _jump_to_session with the tmux navigator functions mocked.
+
+        Patches are applied at the source modules because the functions are
+        lazy-imported inside _jump_to_session.
+        """
+        table_mock = MagicMock()
+        table_mock.is_agent_reachable.return_value = True
+
+        with (
+            patch.object(type(app), "query_one", return_value=table_mock),
+            patch("clorch.tmux.navigator.pid_alive", return_value=True),
+            patch("clorch.tmux.session.TmuxSession") as mock_tmux_cls,
+            patch("clorch.tmux.navigator.jump_to_tmux_tab", return_value=tab_found) as mock_tab,
+            patch("clorch.tmux.navigator.select_tmux_pane", return_value=pane_selected) as mock_pane,
+            patch("clorch.tmux.navigator.bring_terminal_to_front") as mock_front,
+            patch("clorch.tmux.navigator.jump_to_tab", return_value=False),
+        ):
+            app._jump_to_session(agent)
+            return mock_tab, mock_pane, mock_front
+
+    def test_tab_found_skips_select_window(self):
+        """When jump_to_tmux_tab succeeds, select_tmux_pane must NOT be called.
+
+        Calling select-window in a shared session corrupts other clients' views.
+        """
+        app = _make_app()
+        agent = _make_agent()
+        mock_tab, mock_pane, _ = self._run(app, agent, tab_found=True, pane_selected=False)
+
+        mock_tab.assert_called_once()
+        mock_pane.assert_not_called()
+
+    def test_tab_found_brings_terminal_to_front(self):
+        """When jump_to_tmux_tab succeeds, terminal must be raised."""
+        app = _make_app()
+        agent = _make_agent()
+        _, _, mock_front = self._run(app, agent, tab_found=True, pane_selected=False)
+
+        mock_front.assert_called_once()
+
+    def test_tab_found_notifies(self):
+        """When jump_to_tmux_tab succeeds, user sees a 'Jumped to' notification."""
+        app = _make_app()
+        agent = _make_agent()
+        self._run(app, agent, tab_found=True, pane_selected=False)
+
+        app.notify.assert_called_once()
+        assert "Jumped" in app.notify.call_args[0][0]
+
+    def test_fallback_calls_select_pane_when_tab_not_found(self):
+        """When jump_to_tmux_tab fails, select_tmux_pane is called as fallback."""
+        app = _make_app()
+        agent = _make_agent()
+        mock_tab, mock_pane, _ = self._run(app, agent, tab_found=False, pane_selected=True)
+
+        mock_tab.assert_called_once()
+        mock_pane.assert_called_once_with(agent)
+
+    def test_fallback_brings_terminal_to_front(self):
+        """When select_tmux_pane fallback succeeds, terminal must also be raised."""
+        app = _make_app()
+        agent = _make_agent()
+        _, _, mock_front = self._run(app, agent, tab_found=False, pane_selected=True)
+
+        mock_front.assert_called_once()
+
+    def test_fallback_notifies(self):
+        """When select_tmux_pane fallback succeeds, user sees a notification."""
+        app = _make_app()
+        agent = _make_agent()
+        self._run(app, agent, tab_found=False, pane_selected=True)
+
+        app.notify.assert_called_once()
+        assert "Jumped" in app.notify.call_args[0][0]
+
+    def test_no_tmux_window_skips_tmux_path(self):
+        """Agents without tmux_window bypass the tmux branch entirely."""
+        app = _make_app()
+        agent = _make_agent(tmux_window="")
+        mock_tab, mock_pane, mock_front = self._run(app, agent, tab_found=False, pane_selected=False)
+
+        mock_tab.assert_not_called()
+        mock_pane.assert_not_called()
+
+    def test_both_strategies_fail_no_jumped_notification(self):
+        """When both tmux strategies fail, no 'Jumped' notification is shown."""
+        app = _make_app()
+        agent = _make_agent()
+        self._run(app, agent, tab_found=False, pane_selected=False)
+
+        jumped_calls = [
+            c for c in app.notify.call_args_list
+            if "Jumped" in (c[0][0] if c[0] else "")
+        ]
+        assert not jumped_calls

--- a/tests/test_jump_to_session.py
+++ b/tests/test_jump_to_session.py
@@ -51,9 +51,11 @@ class TestJumpToSessionTmuxBranch:
         with (
             patch.object(type(app), "query_one", return_value=table_mock),
             patch("clorch.tmux.navigator.pid_alive", return_value=True),
-            patch("clorch.tmux.session.TmuxSession") as mock_tmux_cls,
+            patch("clorch.tmux.session.TmuxSession"),
             patch("clorch.tmux.navigator.jump_to_tmux_tab", return_value=tab_found) as mock_tab,
-            patch("clorch.tmux.navigator.select_tmux_pane", return_value=pane_selected) as mock_pane,
+            patch(
+                "clorch.tmux.navigator.select_tmux_pane", return_value=pane_selected
+            ) as mock_pane,
             patch("clorch.tmux.navigator.bring_terminal_to_front") as mock_front,
             patch("clorch.tmux.navigator.jump_to_tab", return_value=False),
         ):
@@ -119,7 +121,9 @@ class TestJumpToSessionTmuxBranch:
         """Agents without tmux_window bypass the tmux branch entirely."""
         app = _make_app()
         agent = _make_agent(tmux_window="")
-        mock_tab, mock_pane, mock_front = self._run(app, agent, tab_found=False, pane_selected=False)
+        mock_tab, mock_pane, mock_front = self._run(
+            app, agent, tab_found=False, pane_selected=False
+        )
 
         mock_tab.assert_not_called()
         mock_pane.assert_not_called()
@@ -135,3 +139,29 @@ class TestJumpToSessionTmuxBranch:
             if "Jumped" in (c[0][0] if c[0] else "")
         ]
         assert not jumped_calls
+
+
+class TestJumpToSessionDeadProcess:
+    """Dead-process path uses StateManager.remove_session() (not direct file access)."""
+
+    def test_dead_process_calls_remove_session(self):
+        """When the agent PID is dead, remove_session() is called on the manager."""
+        from clorch.tui.app import OrchestratorApp
+
+        app = object.__new__(OrchestratorApp)
+        app.notify = MagicMock()  # type: ignore[attr-defined]
+        app._manager = MagicMock()
+
+        agent = _make_agent(pid=99999)
+        table_mock = MagicMock()
+        table_mock.is_agent_reachable.return_value = True
+
+        with (
+            patch.object(type(app), "query_one", return_value=table_mock),
+            patch("clorch.tmux.navigator.pid_alive", return_value=False),
+        ):
+            app._jump_to_session(agent)
+
+        app._manager.remove_session.assert_called_once_with(agent.session_id)
+        app.notify.assert_called_once()
+        assert "dead" in app.notify.call_args[0][0]

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -91,6 +91,50 @@ class TestStateManagerGetAgent:
 
 
 # ------------------------------------------------------------------
+# remove_session()
+# ------------------------------------------------------------------
+
+
+class TestStateManagerRemoveSession:
+    """Tests for StateManager.remove_session()."""
+
+    def test_removes_existing_file(self, tmp_state_dir, make_agent_state):
+        """Returns True and deletes the file when it exists."""
+        make_agent_state(session_id="to-remove")
+        mgr = StateManager(state_dir=tmp_state_dir)
+
+        result = mgr.remove_session("to-remove")
+
+        assert result is True
+        assert not (tmp_state_dir / "to-remove.json").exists()
+
+    def test_returns_false_when_missing(self, tmp_state_dir):
+        """Returns False (no error) when the file does not exist."""
+        mgr = StateManager(state_dir=tmp_state_dir)
+        assert mgr.remove_session("nonexistent") is False
+
+    def test_rejects_invalid_session_id(self, tmp_state_dir, make_agent_state):
+        """Rejects session IDs that fail the regex — prevents path traversal."""
+        make_agent_state(session_id="victim")
+        mgr = StateManager(state_dir=tmp_state_dir)
+
+        result = mgr.remove_session("../victim")
+
+        assert result is False
+        assert (tmp_state_dir / "victim.json").exists()
+
+    def test_does_not_affect_other_sessions(self, tmp_state_dir, make_agent_state):
+        """Removing one session leaves others intact."""
+        make_agent_state(session_id="keep-me")
+        make_agent_state(session_id="delete-me")
+        mgr = StateManager(state_dir=tmp_state_dir)
+
+        mgr.remove_session("delete-me")
+
+        assert (tmp_state_dir / "keep-me.json").exists()
+
+
+# ------------------------------------------------------------------
 # get_summary()
 # ------------------------------------------------------------------
 

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,17 +1,12 @@
 """Tests for StateManager."""
 from __future__ import annotations
 
-import json
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-import pytest
 
 from clorch.constants import AgentStatus
 from clorch.state.manager import StateManager
-from clorch.state.models import AgentState
-
 
 # ------------------------------------------------------------------
 # scan()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -58,3 +58,68 @@ class TestGetPaneTarget:
         """Custom pane number is included."""
         tmux = TmuxSession(session_name="sess")
         assert tmux.get_pane_target("backend", pane="2") == "sess:backend.2"
+
+
+# ------------------------------------------------------------------
+# _is_safe_tmux_name()
+# ------------------------------------------------------------------
+
+
+class TestIsSafeTmuxName:
+    """Tests for the _is_safe_tmux_name validation helper."""
+
+    def test_plain_name_is_safe(self):
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name("cre-1") is True
+
+    def test_alphanumeric_with_underscore_is_safe(self):
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name("my_window_2") is True
+
+    def test_empty_string_is_unsafe(self):
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name("") is False
+
+    def test_colon_is_unsafe(self):
+        """Colon is the tmux session:window separator — must be rejected."""
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name("other:window") is False
+
+    def test_double_quote_is_unsafe(self):
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name('win"name') is False
+
+    def test_single_quote_is_unsafe(self):
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name("win'name") is False
+
+    def test_numeric_index_is_safe(self):
+        from clorch.tmux.navigator import _is_safe_tmux_name
+        assert _is_safe_tmux_name("3") is True
+
+
+class TestSelectTmuxPaneValidation:
+    """select_tmux_pane must reject unsafe window targets."""
+
+    def test_rejects_colon_in_window_name(self):
+        """A window name containing ':' would corrupt the tmux target — must return False."""
+        from clorch.tmux.navigator import select_tmux_pane
+        from clorch.state.models import AgentState
+
+        agent = AgentState(
+            session_id="s",
+            tmux_window="evil:session",
+            tmux_session="claude",
+        )
+        with patch("clorch.tmux.navigator.TmuxSession") as mock_cls:
+            mock_tmux = MagicMock()
+            mock_tmux.is_available.return_value = True
+            mock_tmux.exists.return_value = True
+            mock_cls.return_value = mock_tmux
+
+            result = select_tmux_pane(agent)
+
+        assert result is False
+        # select-window must never be called — that's the dangerous command
+        called_subcommands = [c.args[0] for c in mock_tmux.run_command.call_args_list]
+        assert "select-window" not in called_subcommands

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1,10 +1,7 @@
 """Tests for TmuxSession.send_keys() and get_pane_target()."""
 from __future__ import annotations
 
-import subprocess
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 from clorch.tmux.session import TmuxSession
 
@@ -103,8 +100,8 @@ class TestSelectTmuxPaneValidation:
 
     def test_rejects_colon_in_window_name(self):
         """A window name containing ':' would corrupt the tmux target — must return False."""
-        from clorch.tmux.navigator import select_tmux_pane
         from clorch.state.models import AgentState
+        from clorch.tmux.navigator import select_tmux_pane
 
         agent = AgentState(
             session_id="s",


### PR DESCRIPTION
## Bug

When multiple terminal tabs are attached to the **same tmux session** (each showing a different window), pressing `→` in clorch to jump to a session would land on the wrong tab — and corrupt the `clorch-dev` tab by switching it away from the clorch UI.

### Reproduction

```
Tabs:  clorch-dev | cre-1 | cre-2
Tmux:  one shared session, one window per tab

→ on cre-1  →  lands on cre-2's tab, clorch-dev shows cre-1 content ✗
→ on cre-2  →  lands on cre-2's tab (correct), but clorch-dev is still corrupted ✗
```

### Root cause

`_jump_to_session` called `select_tmux_pane` (which issues `tmux select-window`) **before** `jump_to_tmux_tab` (which identifies the correct terminal tab by matching `#{window_name}` in `list-clients` output).

`tmux select-window` is a **session-wide command**: it moves every client attached to the session to the target window simultaneously. So by the time `jump_to_tmux_tab` ran `list-clients`, every client reported the same `window_name` — making it impossible to distinguish which tab belonged to which agent. The first client in the list was always picked, often the wrong one.

The same `select-window` call also corrupted the `clorch-dev` tab, pulling it away from the clorch UI to show the agent's tmux window instead.

## Fix

Swap the order: call `jump_to_tmux_tab` **first** (while each tab still shows its own distinct window), then skip `select-window` entirely if the right tab was found — it's already showing the correct window.

Only fall back to `select_tmux_pane` (and its `select-window` call) when no matching tab is found via tty mapping.

## Additional fixes from code review

- **Missing `bring_terminal_to_front()`** in the `select_tmux_pane` fallback path — terminal would stay in background on non-CC backends (regression)
- **`StateManager.remove_session()`** — TUI was reaching into `_manager._state_dir` directly to delete stale state files; moved to a proper public method with session ID validation to prevent path traversal
- **`_is_safe_tmux_name()` validation** — `tmux_window` / `tmux_window_index` values from state files are now validated to reject `:`, `"`, `'` before being embedded in tmux `-t` target strings

## Tests

- 8 tests covering all branches of the new tab-jump logic
- 4 tests for `StateManager.remove_session()` including path-traversal rejection
- 7 tests for `_is_safe_tmux_name()`
- 1 integration test for the validation guard in `select_tmux_pane`
- 1 test for the dead-process path using `remove_session()`

All 294 tests passing, new code at 100% coverage, zero new lint issues.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)