### PR TITLE
feat: Shift+W hotkey to rename tmux windows from TUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.bak.*
 .claude/
 .ruff_cache/
+.worktrees/

--- a/src/clorch/tmux/session.py
+++ b/src/clorch/tmux/session.py
@@ -208,6 +208,13 @@ class TmuxSession:
         result = self.run_command(*cmd, check=False)
         return result.returncode == 0
 
+    def rename_window(self, window: str, new_name: str) -> bool:
+        """Rename *window* to *new_name*. Returns ``True`` on success."""
+        result = self.run_command(
+            "rename-window", "-t", f"{self.session}:{window}", new_name, check=False
+        )
+        return result.returncode == 0
+
     # ------------------------------------------------------------------
     # Keystroke control
     # ------------------------------------------------------------------

--- a/src/clorch/tui/app.py
+++ b/src/clorch/tui/app.py
@@ -541,6 +541,12 @@ class OrchestratorApp(App):
             event.prevent_default()
             return
 
+        # Shift+W: rename selected agent's tmux window
+        if key == "W":
+            self._rename_selected_window()
+            event.prevent_default()
+            return
+
         # Shift+X: kill selected agent's tmux window
         if key == "X":
             self._kill_agent_window()
@@ -1068,6 +1074,35 @@ class OrchestratorApp(App):
             self.notify(f"Killed window: {name}")
         else:
             self.notify(f"Failed to kill {name}", severity="error")
+
+    def _rename_selected_window(self) -> None:
+        """Prompt for a new name and rename the selected agent's tmux window."""
+        tmux = self._get_tmux()
+        if not tmux:
+            return
+
+        table = self.query_one("#session-list", SessionList)
+        agent = table.get_selected_agent()
+        if not agent:
+            self.notify("No agent selected", severity="warning")
+            return
+
+        from clorch.tmux.navigator import map_agent_to_window
+
+        window = map_agent_to_window(agent, tmux)
+        if not window:
+            self.notify(f"No tmux window for {agent.project_name}", severity="warning")
+            return
+
+        def on_result(new_name: str | None) -> None:
+            if not new_name:
+                return
+            if tmux.rename_window(window, new_name):
+                self.notify(f"Renamed to '{new_name}'")
+            else:
+                self.notify("Rename failed", severity="error")
+
+        self.push_screen(PromptScreen("Rename window:", placeholder=window), on_result)
 
     def _reattach_agent_window(self) -> None:
         """Open an iTerm tab attached to the selected agent's tmux window."""

--- a/tests/test_app_rename_window.py
+++ b/tests/test_app_rename_window.py
@@ -1,0 +1,238 @@
+"""Tests for OrchestratorApp._rename_selected_window."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestRenameSelectedWindow:
+    """Unit tests for _rename_selected_window without a running Textual app.
+
+    Uses object.__new__ to bypass __init__ and calls the method directly,
+    mocking out tmux and SessionList dependencies.
+    """
+
+    def _make_app(self):
+        from clorch.tui.app import OrchestratorApp
+
+        return object.__new__(OrchestratorApp)
+
+    def _make_agent(self, project_name: str = "myproject") -> MagicMock:
+        agent = MagicMock()
+        agent.project_name = project_name
+        return agent
+
+    # ------------------------------------------------------------------
+    # Guard: no tmux
+    # ------------------------------------------------------------------
+
+    def test_no_tmux_returns_early(self):
+        """Returns early (no notify, no push_screen) when tmux is unavailable."""
+        app = self._make_app()
+        app._get_tmux = MagicMock(return_value=None)
+        app.notify = MagicMock()
+        app.push_screen = MagicMock()
+
+        app._rename_selected_window()
+
+        app.notify.assert_not_called()
+        app.push_screen.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Guard: no agent selected
+    # ------------------------------------------------------------------
+
+    def test_no_agent_selected_notifies(self):
+        """Notifies with warning when no agent is selected."""
+        app = self._make_app()
+        tmux = MagicMock()
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+        app.push_screen = MagicMock()
+
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = None
+        app.query_one = MagicMock(return_value=session_list)
+
+        app._rename_selected_window()
+
+        app.notify.assert_called_once_with("No agent selected", severity="warning")
+        app.push_screen.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Guard: no tmux window mapped
+    # ------------------------------------------------------------------
+
+    def test_no_tmux_window_notifies(self):
+        """Notifies with warning when agent has no mapped tmux window."""
+        app = self._make_app()
+        tmux = MagicMock()
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+        app.push_screen = MagicMock()
+
+        agent = self._make_agent("myproject")
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = agent
+        app.query_one = MagicMock(return_value=session_list)
+
+        with patch("clorch.tmux.navigator.map_agent_to_window", return_value=None):
+            app._rename_selected_window()
+
+        app.notify.assert_called_once_with("No tmux window for myproject", severity="warning")
+        app.push_screen.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Prompt cancelled
+    # ------------------------------------------------------------------
+
+    def test_prompt_cancelled_no_rename(self):
+        """Does not call rename_window when prompt is cancelled (None result)."""
+        app = self._make_app()
+        tmux = MagicMock()
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+
+        agent = self._make_agent()
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = agent
+        app.query_one = MagicMock(return_value=session_list)
+
+        captured_callback = {}
+
+        def fake_push_screen(screen, callback=None):
+            captured_callback["fn"] = callback
+
+        app.push_screen = fake_push_screen
+
+        with patch("clorch.tmux.navigator.map_agent_to_window", return_value="mywin"):
+            app._rename_selected_window()
+
+        # Simulate user cancelling the prompt
+        captured_callback["fn"](None)
+
+        tmux.rename_window.assert_not_called()
+        app.notify.assert_not_called()
+
+    def test_prompt_empty_string_no_rename(self):
+        """Does not call rename_window when prompt returns empty string."""
+        app = self._make_app()
+        tmux = MagicMock()
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+
+        agent = self._make_agent()
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = agent
+        app.query_one = MagicMock(return_value=session_list)
+
+        captured_callback = {}
+
+        def fake_push_screen(screen, callback=None):
+            captured_callback["fn"] = callback
+
+        app.push_screen = fake_push_screen
+
+        with patch("clorch.tmux.navigator.map_agent_to_window", return_value="mywin"):
+            app._rename_selected_window()
+
+        captured_callback["fn"]("")
+
+        tmux.rename_window.assert_not_called()
+        app.notify.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Rename succeeds
+    # ------------------------------------------------------------------
+
+    def test_rename_success_notifies(self):
+        """Notifies with success message when rename_window returns True."""
+        app = self._make_app()
+        tmux = MagicMock()
+        tmux.rename_window.return_value = True
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+
+        agent = self._make_agent()
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = agent
+        app.query_one = MagicMock(return_value=session_list)
+
+        captured_callback = {}
+
+        def fake_push_screen(screen, callback=None):
+            captured_callback["fn"] = callback
+
+        app.push_screen = fake_push_screen
+
+        with patch("clorch.tmux.navigator.map_agent_to_window", return_value="mywin"):
+            app._rename_selected_window()
+
+        captured_callback["fn"]("shiny-new")
+
+        tmux.rename_window.assert_called_once_with("mywin", "shiny-new")
+        app.notify.assert_called_once_with("Renamed to 'shiny-new'")
+
+    # ------------------------------------------------------------------
+    # Rename fails
+    # ------------------------------------------------------------------
+
+    def test_rename_failure_notifies_error(self):
+        """Notifies with error severity when rename_window returns False."""
+        app = self._make_app()
+        tmux = MagicMock()
+        tmux.rename_window.return_value = False
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+
+        agent = self._make_agent()
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = agent
+        app.query_one = MagicMock(return_value=session_list)
+
+        captured_callback = {}
+
+        def fake_push_screen(screen, callback=None):
+            captured_callback["fn"] = callback
+
+        app.push_screen = fake_push_screen
+
+        with patch("clorch.tmux.navigator.map_agent_to_window", return_value="mywin"):
+            app._rename_selected_window()
+
+        captured_callback["fn"]("badname")
+
+        tmux.rename_window.assert_called_once_with("mywin", "badname")
+        app.notify.assert_called_once_with("Rename failed", severity="error")
+
+    # ------------------------------------------------------------------
+    # PromptScreen pre-filled with current window name
+    # ------------------------------------------------------------------
+
+    def test_prompt_screen_placeholder_is_window_name(self):
+        """PromptScreen is opened with the current window name as placeholder."""
+        from clorch.tui.app import PromptScreen
+
+        app = self._make_app()
+        tmux = MagicMock()
+        app._get_tmux = MagicMock(return_value=tmux)
+        app.notify = MagicMock()
+
+        agent = self._make_agent()
+        session_list = MagicMock()
+        session_list.get_selected_agent.return_value = agent
+        app.query_one = MagicMock(return_value=session_list)
+
+        pushed_screens = []
+
+        def fake_push_screen(screen, callback=None):
+            pushed_screens.append(screen)
+
+        app.push_screen = fake_push_screen
+
+        with patch("clorch.tmux.navigator.map_agent_to_window", return_value="cobra"):
+            app._rename_selected_window()
+
+        assert len(pushed_screens) == 1
+        screen = pushed_screens[0]
+        assert isinstance(screen, PromptScreen)
+        assert screen._placeholder == "cobra"

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1,4 +1,4 @@
-"""Tests for TmuxSession.send_keys() and get_pane_target()."""
+"""Tests for TmuxSession.send_keys(), get_pane_target(), and rename_window()."""
 from __future__ import annotations
 
 import subprocess
@@ -42,6 +42,31 @@ class TestSendKeys:
         with patch.object(tmux, "run_command") as mock_run:
             mock_run.return_value = MagicMock(returncode=1)
             result = tmux.send_keys("test:win.0", "y")
+
+        assert result is False
+
+
+class TestRenameWindow:
+    """Tests for TmuxSession.rename_window()."""
+
+    def test_rename_window_success(self):
+        """Returns True and calls rename-window with correct target."""
+        tmux = TmuxSession(session_name="test")
+        with patch.object(tmux, "run_command") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = tmux.rename_window("mywin", "newname")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            "rename-window", "-t", "test:mywin", "newname", check=False,
+        )
+
+    def test_rename_window_failure(self):
+        """Returns False when tmux command exits non-zero."""
+        tmux = TmuxSession(session_name="test")
+        with patch.object(tmux, "run_command") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            result = tmux.rename_window("mywin", "newname")
 
         assert result is False
 


### PR DESCRIPTION
## Summary

- Adds `TmuxSession.rename_window(window, new_name) -> bool` using the existing `run_command` helper
- Adds `Shift+W` branch in `OrchestratorApp.on_key()` → calls `_rename_selected_window()`
- `_rename_selected_window()` opens `PromptScreen` pre-filled with current window name; on confirm calls `rename_window` and notifies success/failure
- Guards: no tmux available, no agent selected, no tmux window mapped, prompt cancelled

## Test plan

- [x] `TestRenameWindow` — success/failure paths for `TmuxSession.rename_window()`
- [x] `TestRenameSelectedWindow` — 8 cases: no tmux, no agent, no window, prompt cancelled, empty string, rename succeeds, rename fails, placeholder pre-filled
- [x] Full suite: 320 tests passing
- [x] Zero new lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)